### PR TITLE
Fix audio cutoff issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.10'
+def runeLiteVersion = '1.8.28'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/hunllefhelper/AudioPlayer.java
+++ b/src/main/java/com/hunllefhelper/AudioPlayer.java
@@ -39,7 +39,7 @@ public class AudioPlayer
 		{
 			Clip clip = clips.get(sound);
 			clip.setFramePosition(0);
-			clip.loop(1);
+			clip.start();
 		}
 	}
 

--- a/src/main/java/com/hunllefhelper/AudioPlayer.java
+++ b/src/main/java/com/hunllefhelper/AudioPlayer.java
@@ -38,14 +38,8 @@ public class AudioPlayer
 		if (clips.containsKey(sound))
 		{
 			Clip clip = clips.get(sound);
-			if (clip.getFramePosition() == 0)
-			{
-				clip.start();
-			}
-			else
-			{
-				clip.loop(1);
-			}
+			clip.setFramePosition(0);
+			clip.loop(1);
 		}
 	}
 


### PR DESCRIPTION
I am also experiencing Issue #16. After debugging on my system I noticed that the clip frame continues upward endlessly. I think that what's happening is that sometimes the thread scheduler arrives a little late so when one audio clip starts, it ends the previous one *just* before it completes. [When it resumes that Clip then it only plays the last few frames (which explains why it's intermittently silent)](https://docs.oracle.com/javase/7/docs/api/javax/sound/sampled/Clip.html#loop(int)). I've been testing these changes to force the frame back to the beginning before looping the audio once and so far I haven't experienced a single cutoff in the audio.
